### PR TITLE
oidc-client fix for angular aot 

### DIFF
--- a/angular-cli.json
+++ b/angular-cli.json
@@ -21,8 +21,8 @@
         "styles.css"
       ],
       "scripts": [],
+      "environmentSource": "environments/environment.ts",
       "environments": {
-        "source": "environments/environment.ts",
         "dev": "environments/environment.ts",
         "prod": "environments/environment.prod.ts"
       }

--- a/package.json
+++ b/package.json
@@ -13,25 +13,25 @@
   },
   "private": true,
   "dependencies": {
-    "@angular/common": "^2.3.1",
-    "@angular/compiler": "^2.3.1",
-    "@angular/core": "^2.3.1",
-    "@angular/forms": "^2.3.1",
-    "@angular/http": "^2.3.1",
-    "@angular/platform-browser": "^2.3.1",
-    "@angular/platform-browser-dynamic": "^2.3.1",
-    "@angular/router": "^3.3.1",
+    "@angular/common": "^4.2.2",
+    "@angular/compiler": "^4.2.2",
+    "@angular/core": "^4.2.2",
+    "@angular/forms": "^4.2.2",
+    "@angular/http": "^4.2.2",
+    "@angular/platform-browser": "^4.2.2",
+    "@angular/platform-browser-dynamic": "^4.2.2",
+    "@angular/router": "^4.2.2",
     "core-js": "^2.4.1",
     "oidc-client": "^1.2.2",
-    "rxjs": "^5.0.1",
+    "rxjs": "^5.4.0",
     "ts-helpers": "^1.1.1",
-    "zone.js": "^0.7.2"
+    "zone.js": "^0.8.12"
   },
   "devDependencies": {
-    "@angular/compiler-cli": "^2.3.1",
+    "@angular/cli": "^1.1.1",
+    "@angular/compiler-cli": "^4.2.2",
     "@types/jasmine": "2.5.38",
-    "@types/node": "^6.0.42",
-    "angular-cli": "1.0.0-beta.25.5",
+    "@types/node": "^7.0.31",
     "codelyzer": "~2.0.0-beta.1",
     "extract-text-webpack-plugin": "^2.0.0-rc.0",
     "jasmine-core": "2.5.2",
@@ -44,6 +44,6 @@
     "protractor": "~4.0.13",
     "ts-node": "1.2.1",
     "tslint": "^4.3.0",
-    "typescript": "~2.0.3"
+    "typescript": "~2.3.4"
   }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
-import { NgModule } from '@angular/core';
+import { InjectionToken, NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 
@@ -12,12 +12,14 @@ const settings = { /* ... */ };
 
 const userManager = new UserManager(settings);
 
+export const userManagerToken: InjectionToken<UserManager> = new InjectionToken("UserManagerToken");
+
 export function getUserManager() {
   return userManager;
 }
 
 export const UserManagerProvider: FactoryProvider = {
-  provide: UserManager,
+  provide: userManagerToken,
   useFactory: getUserManager
 };
 


### PR DESCRIPTION
Angular upgraded to current version (4.2.2) and wrapped oidc-client in an InjectionToken.
It should also work in Angular 2 using OpaqueToken